### PR TITLE
Create zh_cn.json

### DIFF
--- a/src/main/resources/assets/beaconsforall/lang/zh_cn.json
+++ b/src/main/resources/assets/beaconsforall/lang/zh_cn.json
@@ -2,10 +2,10 @@
   "text.autoconfig.beaconsforall.title": "公共信标",
   "text.autoconfig.beaconsforall.option.creatureType": "受影响的生物类型",
   "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[0]": "选择会受信标效果影响的生物类型",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE： 没有生物被影响",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "TAMED： 所有被驯服的生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "PASSIVE： 所有被动型生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "ALL： 所有生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE: 没有生物被影响",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "TAMED: 所有被驯服的生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "PASSIVE: 所有被动型生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "ALL: 所有生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures": "指定生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures.@Tooltip": "受信标影响的特定生物的命名空间 ID 列表"
 }

--- a/src/main/resources/assets/beaconsforall/lang/zh_cn.json
+++ b/src/main/resources/assets/beaconsforall/lang/zh_cn.json
@@ -1,0 +1,11 @@
+{
+  "text.autoconfig.beaconsforall.title": "公共信标",
+  "text.autoconfig.beaconsforall.option.creatureType": "受影响的生物类型",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[0]": "选择会受信标效果影响的生物类型",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "无：没有生物被影响",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "驯服：所有被驯服的生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "被动：所有被动型生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "全部：所有生物",
+  "text.autoconfig.beaconsforall.option.additionalCreatures": "指定生物",
+  "text.autoconfig.beaconsforall.option.additionalCreatures.@Tooltip": "受信标影响的特定生物的命名空间 ID 列表"
+}

--- a/src/main/resources/assets/beaconsforall/lang/zh_cn.json
+++ b/src/main/resources/assets/beaconsforall/lang/zh_cn.json
@@ -2,10 +2,10 @@
   "text.autoconfig.beaconsforall.title": "公共信标",
   "text.autoconfig.beaconsforall.option.creatureType": "受影响的生物类型",
   "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[0]": "选择会受信标效果影响的生物类型",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "无：没有生物被影响",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "驯服：所有被驯服的生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "被动：所有被动型生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "全部：所有生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE：没有生物被影响",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "TAMED：所有被驯服的生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "PASSIVE：所有被动型生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "ALL：所有生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures": "指定生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures.@Tooltip": "受信标影响的特定生物的命名空间 ID 列表"
 }

--- a/src/main/resources/assets/beaconsforall/lang/zh_cn.json
+++ b/src/main/resources/assets/beaconsforall/lang/zh_cn.json
@@ -2,10 +2,10 @@
   "text.autoconfig.beaconsforall.title": "公共信标",
   "text.autoconfig.beaconsforall.option.creatureType": "受影响的生物类型",
   "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[0]": "选择会受信标效果影响的生物类型",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE：没有生物被影响",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "TAMED：所有被驯服的生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "PASSIVE：所有被动型生物",
-  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "ALL：所有生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE： 没有生物被影响",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[2]": "TAMED： 所有被驯服的生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[3]": "PASSIVE： 所有被动型生物",
+  "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[4]": "ALL： 所有生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures": "指定生物",
   "text.autoconfig.beaconsforall.option.additionalCreatures.@Tooltip": "受信标影响的特定生物的命名空间 ID 列表"
 }

--- a/src/main/resources/assets/beaconsforall/lang/zh_cn.json
+++ b/src/main/resources/assets/beaconsforall/lang/zh_cn.json
@@ -1,5 +1,5 @@
 {
-  "text.autoconfig.beaconsforall.title": "公共信标",
+  "text.autoconfig.beaconsforall.title": "公共信标 (Beacons For All)",
   "text.autoconfig.beaconsforall.option.creatureType": "受影响的生物类型",
   "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[0]": "选择会受信标效果影响的生物类型",
   "text.autoconfig.beaconsforall.option.creatureType.@Tooltip[1]": "NONE: 没有生物被影响",


### PR DESCRIPTION
The translation of "Beacons for All" committed in this file is slightly changed to the meaning of "Public Beacons" in English, which should be a more natural way to convey the information of "Beacons shared by everyone" in Chinese naming. 

BTW, it would be better for the description part to remind users to enable mobGriefing, otherwise players who disable it for terrain protection from creepers etc. may get confused. 